### PR TITLE
query with parameter

### DIFF
--- a/data-source/ticketmaster.js
+++ b/data-source/ticketmaster.js
@@ -9,10 +9,10 @@ class TicketmasterApi extends RESTDataSource {
       request.params.set('apikey', this.context.token);
     }
   
-    async getMostRelevantEvents(limit = 10) {
-      const data = await this.get('events.json');
+    async getMostRelevantEvents(city) {
+      const data = await this.get('events.json', { city });
   
-      return data._embedded.events;
+      return data._embedded && data._embedded.events;
     }
 }
 

--- a/resolvers.js
+++ b/resolvers.js
@@ -1,13 +1,11 @@
 const resolvers = {
     Query: {
-      mostRelevantEvents: async (_src, _args, { dataSources }) => {
-        return dataSources.ticketmasterApi.getMostRelevantEvents();
+      mostRelevantEvents: async (_src, { city }, { dataSources }) => {
+        return await dataSources.ticketmasterApi.getMostRelevantEvents(city) || [];
       },
     },
     Event: {
-      image: (event) => {
-        return event.images.find((image) => image.ratio === '16_9' && image.width === 640);
-      },
+      images: (event) => event.images.filter((image) => image.ratio === '16_9'),
     },
 };
 

--- a/schema.js
+++ b/schema.js
@@ -2,7 +2,7 @@ const { gql } = require('apollo-server');
 
 const typeDefs = gql`
   type Query {
-    mostRelevantEvents: [Event]!
+    mostRelevantEvents(city: String!): [Event!]!
   }
 
   type Event {
@@ -10,21 +10,16 @@ const typeDefs = gql`
     name: String!
     dates: Dates!
     """
-    Actually an array of images:
-    | Ratio | Width | Height | Purpose |
-    | ----- | ----- | ------ | ------- |
-    |16_9| 2048| 1152| tablet LC Large |
-    |16_9| 1136|  639| retina landscape|
-    |16_9| 1024|  576| tablet landscape|
-    |16_9|  640|  360| retina portait  |
-    |16_9|  205|  115| event detail    |
-    |16_9|  100|   56| recomendation   |
-    | 3_2|  640|  427| retina portait  |
-    | 3_2|  305|  203| artist page     |
-    | 3_2| 1024|  638| tablet landscape|
-    | 4_3|  305|  225| custom          |
+    | Width | Height | Purpose |
+    | ----- | ------ | ------- |
+    | 2048| 1152| tablet LC Large |
+    | 1136|  639| retina landscape|
+    | 1024|  576| tablet landscape|
+    |  640|  360| retina portait  |
+    |  100|   56| recomendation   |
+    |  205|  115| event detail    |
     """
-    image: Image!
+    images: [Image!]!
   }
 
   type Image {


### PR DESCRIPTION
images
- decided for images with 16x9 ratio
- return all fitting images and let client select specific one(s)

let client filter 'relevant events' by city
- decided that the API will be non-opinionated. hence, no default values
- decided, for now, the API will be non-nullable. hence, always an array of events

