### PR TITLE
provide manual schema typing for resolver

### DIFF
--- a/src/data-source/ticketmaster.ts
+++ b/src/data-source/ticketmaster.ts
@@ -1,9 +1,5 @@
 import { RESTDataSource, RequestOptions } from 'apollo-datasource-rest';
-
-export interface EventsPage {
-  events: Object[];
-  hasMore: boolean;
-};
+import { EventsPage } from 'src/schema';
 
 export default class TicketmasterApi extends RESTDataSource {
   private readonly TMmaxItems = 1000;

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,18 +1,20 @@
-import { IResolvers } from "graphql-tools";
-import TicketmasterApi, { EventsPage } from "./data-source/ticketmaster";
+import { IResolverObject } from "graphql-tools";
+import { EventsPage, Query, ResolverContext, Event } from './schema';
 
-const resolvers: IResolvers = {
-  Query: {
-    eventsPage: async (_src: any, { page, city }: any, { dataSources }: any): Promise<EventsPage> => {
-      return await (dataSources.ticketmasterApi as TicketmasterApi).getEventsPage(page, city) || {
-          events: [],
-          hasMore: false,
-      };
-    },
-  },
-  Event: {
-    images: (event: any) => event.images.filter((image: any) => image.ratio === '16_9'),
+const Query: IResolverObject<undefined, ResolverContext> = {
+  eventsPage: async (_src, { page, city }, { dataSources }): Promise<EventsPage> => {
+    return await dataSources.ticketmasterApi.getEventsPage(page, city) || {
+      events: [],
+      hasMore: false,
+    };
   },
 };
 
-export default resolvers;
+const Event: IResolverObject<Event, ResolverContext> = {
+  images: (event) => event.images.filter((image) => image.ratio === '16_9'),
+}
+
+export default {
+  Query,
+  Event,
+};

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,4 +1,5 @@
 import { gql } from 'apollo-server';
+import TicketmasterApi from './data-source/ticketmaster';
 
 export default gql`
   type Query {
@@ -45,3 +46,37 @@ export default gql`
     localTime: String
   }
 `;
+
+export interface ResolverContext {
+  dataSources: {
+    ticketmasterApi: TicketmasterApi;
+  }
+}
+
+export interface Query {
+  eventsPage: EventsPage;
+}
+
+export interface EventsPage {
+  events: Array<Event>;
+  hasMore: Boolean;
+};
+
+export interface Event {
+  id: number;
+  name: string;
+  dates: Array<{
+    start: {
+      localDate: string;
+      localTime: string;
+    }
+    timezone: string;
+    spanMultipleDays: Boolean;
+  }>;
+  images: Array<{
+    ratio: string;
+    url: string;
+    width: number;
+    height: number;
+  }>;
+};


### PR DESCRIPTION
Apollo's CLI generates typings only based on queries, mutations and subscriptions. Hence, there's currently no way to auto-generate all types an API has to offer.

As a workaround I hardcoded them for now and used them to type type the resolvers.